### PR TITLE
Add allowplugins settting for some Composer plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,11 @@
     "test": "phpunit --colors=always"
   },
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "infection/extension-installer": true,
+      "phpro/grumphp": true
+    }
   },
   "extra": {
     "laminas": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Since the `Composer 2.2` is released, it needs to add the `allow-plugins` setting to be restricted to manage the Composer plugins. Otherwise it will throw following exception message when running the `composer update` command:

```
In PluginManager.php line 744:
                                                                               
  infection/extension-installer contains a Composer plugin which is blocked b  
  y your allow-plugins config. You may add it to the list if you consider it   
  safe.                                                                        
  You can run "composer config --no-plugins allow-plugins.infection/extension  
  -installer [true|false]" to enable it (true) or disable it explicitly and s  
  uppress this exception (false)                                               
  See https://getcomposer.org/allow-plugins          
......
  phpro/grumphp contains a Composer plugin which is blocked by your allow-plu  
  gins config. You may add it to the list if you consider it safe.             
  You can run "composer config --no-plugins allow-plugins.phpro/grumphp [true  
  |false]" to enable it (true) or disable it explicitly and suppress this exc  
  eption (false)                                                               
  See https://getcomposer.org/allow-plugins 
```

## Motivation and context

N/A

## How has this been tested?

N/A

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Composer setting fix

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [X] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
